### PR TITLE
Decode response content to convert bytes to str.

### DIFF
--- a/pyetcd/__init__.py
+++ b/pyetcd/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import codecs
 
 __author__ = 'TwinDB Development Team'
 __email__ = 'dev@twindb.com'
@@ -259,8 +260,8 @@ class EtcdResult(object):
         except (TypeError, AttributeError):
             pass
         try:
-            self._response_content = response.content
-            self._payload = json.loads(response.content)
+            self._response_content = codecs.decode(response.content)
+            self._payload = json.loads(self._response_content)
             self._raise_for_status(self._payload)
         except (ValueError, TypeError, AttributeError) as err:
             raise EtcdException(err)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -74,7 +74,7 @@ def test_client_raises_exception_if_unsupported_protocol():
 @mock.patch('pyetcd.client.requests')
 def test_write(mock_requests, default_etcd, payload_write_success):
     mock_requests.put.return_value = mock.Mock(content=payload_write_success)
-    response = default_etcd.write('/messsage', 'Hello world')
+    response = default_etcd.write('/messsage', b'Hello world')
     assert response.action == 'set'
     assert response.node['value'] == 'Hello world'
 


### PR DESCRIPTION
Came across this issue on Python 3, the response content is encoded as 'bytes' in version 3 and needs to be decoded to str.
#6 